### PR TITLE
Update JSONSchema version, add linting and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This convention defines [brief description of what this convention does]. All pr
 [Add more detailed description of the convention, its purpose, and how it fits into the Zarr ecosystem. Explain what problem it solves and how it should be used.]
 
 - Examples:
-    - [Convention metadata only](examples/minimal_example.json)
-    - [Key-prefixed pattern (recommended)](examples/key_prefixed_example.json)
-    - [Nested pattern](examples/nested_example.json)
+  - [Convention metadata only](examples/minimal_example.json)
+  - [Key-prefixed pattern (recommended)](examples/key_prefixed_example.json)
+  - [Nested pattern](examples/nested_example.json)
 
 ## Motivation
 
@@ -68,12 +68,11 @@ Individual attributes are prefixed with `template:`. This is the recommended app
 | template:another_one | \[number]                 | Describe the field...                        |
 
 **Example**:
+
 ```json
 {
   "attributes": {
-    "zarr_conventions": [
-      { "name": "template:", "spec_url": "..." }
-    ],
+    "zarr_conventions": [{ "name": "template:", "spec_url": "..." }],
     "template:new_field": "example value",
     "template:xyz": { "x": 1.0, "y": 2.0, "z": 3.0 }
   }
@@ -86,17 +85,16 @@ All convention properties are nested under a single `template` key.
 
 **Convention metadata name**: `template`
 
-| Field Name           | Type                      | Description                                  |
-| -------------------- | ------------------------- | -------------------------------------------- |
-| template             | [Template Object](#template-object) | **REQUIRED**. Template convention properties |
+| Field Name | Type                                | Description                                  |
+| ---------- | ----------------------------------- | -------------------------------------------- |
+| template   | [Template Object](#template-object) | **REQUIRED**. Template convention properties |
 
 **Example**:
+
 ```json
 {
   "attributes": {
-    "zarr_conventions": [
-      { "name": "template", "spec_url": "..." }
-    ],
+    "zarr_conventions": [{ "name": "template", "spec_url": "..." }],
     "template": {
       "new_field": "example value",
       "xyz": { "x": 1.0, "y": 2.0, "z": 3.0 }
@@ -109,11 +107,11 @@ All convention properties are nested under a single `template` key.
 
 When using the nested pattern, all properties are contained in the `template` object:
 
-| Field Name   | Type                      | Description                                  |
-| ------------ | ------------------------- | -------------------------------------------- |
-| new_field    | string                    | **REQUIRED**. Describe the required field... |
-| xyz          | [XYZ Object](#xyz-object) | Describe the field...                        |
-| another_one  | \[number]                 | Describe the field...                        |
+| Field Name  | Type                      | Description                                  |
+| ----------- | ------------------------- | -------------------------------------------- |
+| new_field   | string                    | **REQUIRED**. Describe the required field... |
+| xyz         | [XYZ Object](#xyz-object) | Describe the field...                        |
+| another_one | \[number]                 | Describe the field...                        |
 
 ### Additional Field Information
 
@@ -159,7 +157,7 @@ This section helps potential implementers assess the convention's maturity and a
 - Tutorials, blog posts, or other resources demonstrating this convention
 - Community discussions or working groups
 
-*If you implement or use this convention, please add your implementation to this list by submitting a pull request.*
+_If you implement or use this convention, please add your implementation to this list by submitting a pull request._
 
 ## Acknowledgements
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,9 @@
+import json from "@eslint/json";
+import markdown from "@eslint/markdown";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  { files: ["**/*.js"] },
+  { files: ["**/*.json"], plugins: { json }, language: "json/json" },
+  { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm" },
+]);

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "name": "zarr-convention-metadata-template",
   "version": "0.1.0",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "fmt": "prettier --write **/*.{js,json,md}"
   },
   "devDependencies": {
-    "ajv": "^8.12.0"
+    "ajv": "^8.17.1",
+    "prettier": "^3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "version": "0.1.0",
   "scripts": {
     "test": "node test.js",
-    "fmt": "prettier --write **/*.{js,json,md}"
+    "fmt": "prettier --write **/*.{js,json,md}",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "ajv": "^8.17.1",
-    "prettier": "^3.7.4"
+    "eslint": "^9.39.2",
+    "prettier": "^3.7.4",
+    "@eslint/json": "^0.14.0",
+    "@eslint/markdown": "^7.5.1"
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Template Convention",
   "description": "Schema for Template Zarr convention, supporting both key-prefixed and nested namespace patterns",
   "type": "object",

--- a/test.js
+++ b/test.js
@@ -1,53 +1,55 @@
 #!/usr/bin/env node
-import { readdir } from 'fs/promises';
-import { join, extname } from 'path';
-import { execSync } from 'child_process';
+import { readdir } from "fs/promises";
+import { join, extname } from "path";
+import { execSync } from "child_process";
 
-const examplesDir = 'examples';
-const schemaFile = 'schema.json';
+const examplesDir = "examples";
+const schemaFile = "schema.json";
 
 async function runTests() {
-  console.log('🧪 Running validation tests...\n');
-  
+  console.log("🧪 Running validation tests...\n");
+
   try {
     const files = await readdir(examplesDir);
-    const jsonFiles = files.filter(file => extname(file) === '.json');
-    
+    const jsonFiles = files.filter((file) => extname(file) === ".json");
+
     if (jsonFiles.length === 0) {
-      console.log('⚠️  No JSON files found in examples directory');
+      console.log("⚠️  No JSON files found in examples directory");
       process.exit(1);
     }
-    
+
     let passed = 0;
     let failed = 0;
-    
+
     for (const file of jsonFiles) {
       const filePath = join(examplesDir, file);
       process.stdout.write(`Testing ${file}... `);
-      
+
       try {
         execSync(`node validate.js ${schemaFile} ${filePath}`, {
-          stdio: 'pipe',
-          encoding: 'utf8'
+          stdio: "pipe",
+          encoding: "utf8",
         });
-        console.log('✅ PASSED');
+        console.log("✅ PASSED");
         passed++;
       } catch (error) {
-        console.log('❌ FAILED');
+        console.log("❌ FAILED");
         console.log(error.stdout || error.message);
         failed++;
       }
     }
-    
-    console.log('\n' + '='.repeat(50));
-    console.log(`Total: ${jsonFiles.length} | Passed: ${passed} | Failed: ${failed}`);
-    console.log('='.repeat(50));
-    
+
+    console.log("\n" + "=".repeat(50));
+    console.log(
+      `Total: ${jsonFiles.length} | Passed: ${passed} | Failed: ${failed}`,
+    );
+    console.log("=".repeat(50));
+
     if (failed > 0) {
       process.exit(1);
     }
   } catch (error) {
-    console.error('Error running tests:', error.message);
+    console.error("Error running tests:", error.message);
     process.exit(1);
   }
 }

--- a/validate.js
+++ b/validate.js
@@ -1,29 +1,29 @@
-import Ajv from 'ajv';
-import fs from 'fs';
+import Ajv2020 from "ajv/dist/2020.js";
+import fs from "fs";
 
 // Read command line arguments
 const schemaPath = process.argv[2];
 const dataPath = process.argv[3];
 
 if (!schemaPath || !dataPath) {
-  console.error('Usage: node validate.js <schema.json> <data.json>');
+  console.error("Usage: node validate.js <schema.json> <data.json>");
   process.exit(1);
 }
 
 // Read files
-const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
 
 // Validate
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv2020({ allErrors: true });
 const validate = ajv.compile(schema);
 const valid = validate(data);
 
 if (valid) {
-  console.log('✅ Validation successful!');
+  console.log("✅ Validation successful!");
   process.exit(0);
 } else {
-  console.log('❌ Validation failed!');
+  console.log("❌ Validation failed!");
   console.log(JSON.stringify(validate.errors, null, 2));
   process.exit(1);
 }


### PR DESCRIPTION
Uses JSONSchema draft 2020-12. Adds prettier formatting and eslint linting for JS, JSON and MD files.

Resolves #8 .

It would probably be useful to add github CI configuration too.